### PR TITLE
Removed deprecated Maven usages

### DIFF
--- a/hpi/pom.xml
+++ b/hpi/pom.xml
@@ -54,7 +54,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>shaded</artifactId>
-            <version>${parent.version}</version>
+            <version>${project.parent.version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>*</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -39,10 +39,6 @@
             <id>findify</id>
             <url>https://dl.bintray.com/findify/maven/</url>
         </repository>
-        <repository>
-            <id>maven2</id>
-            <url>http://central.maven.org/maven2</url>
-        </repository>
     </repositories>
 
     <pluginRepositories>


### PR DESCRIPTION
These are a small changes in order to avoid some Apache Maven warnings.

/cc @phuonghuynh 